### PR TITLE
siva: implement PackfileWriter and Filesystem in storer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,11 @@
 language: go
 
 go:
+  - 1.12.x
   - 1.11.x
-  - tip
 go_import_path: github.com/src-d/go-borges
+env:
+  - GO111MODULE=on
 
 matrix:
   fast_finish: true
@@ -11,6 +13,9 @@ matrix:
     - go: tip
 
 script:
+  # go-git-fixtures cannot find the data directory if it's not in vendor
+  # or in GOPATH. This will be deleted after it is fixed.
+  - GO111MODULE=off go get gopkg.in/src-d/go-git-fixtures.v3
   - make dependencies
   - make test-coverage
   - make codecov

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,22 @@
+module github.com/src-d/go-borges
+
+go 1.12
+
+require (
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.1
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/pkg/errors v0.8.1 // indirect
+	github.com/stretchr/testify v1.3.0
+	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 // indirect
+	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
+	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
+	gopkg.in/src-d/go-billy-siva.v4 v4.5.0
+	gopkg.in/src-d/go-billy.v4 v4.3.0
+	gopkg.in/src-d/go-errors.v1 v1.0.0
+	gopkg.in/src-d/go-git-fixtures.v3 v3.3.0
+	gopkg.in/src-d/go-git.v4 v4.0.0-20190208090203-dcc9f375f4da
+	gopkg.in/src-d/go-siva.v1 v1.5.0 // indirect
+)
+
+replace gopkg.in/src-d/go-git.v4 => github.com/src-d/go-git v0.0.0-20190322182544-79081164bccd

--- a/plain/repository.go
+++ b/plain/repository.go
@@ -160,7 +160,7 @@ func (r *Repository) Commit() (err error) {
 	}
 
 	defer ioutil.CheckClose(r, &err)
-	ts, ok := r.Storer.(*transactional.Storage)
+	ts, ok := r.Storer.(transactional.Storage)
 	if !ok {
 		panic("unreachable code")
 	}


### PR DESCRIPTION
`PackfileWriter` is used to fetch repository changes and store them in pack format. `Filesystem` allows to directly copy previously downloaded packfiles on new siva files.

It also makes it compatible with src-d/go-git#1093

Fixes #9 