### PR TITLE
 siva: do not cache read only filesystem

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 // indirect
 	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
 	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
-	gopkg.in/src-d/go-billy-siva.v4 v4.5.0
+	gopkg.in/src-d/go-billy-siva.v4 v4.5.1
 	gopkg.in/src-d/go-billy.v4 v4.3.0
 	gopkg.in/src-d/go-errors.v1 v1.0.0
 	gopkg.in/src-d/go-git-fixtures.v3 v3.3.0

--- a/siva/location_test.go
+++ b/siva/location_test.go
@@ -269,7 +269,7 @@ func (s *locationSuite) TestFS() {
 	loc, ok := location.(*Location)
 	require.True(ok)
 
-	fs, err := loc.FS()
+	fs, err := loc.FS(borges.ReadOnlyMode)
 	require.NoError(err)
 
 	stat, err := fs.Stat("objects/pack/pack-bb25e08fc37bda477660be0609a356f6d1e65ffc.pack")


### PR DESCRIPTION
Instead of having a cached filesystem for read only repositories open it for each repository. It gets the offset for the index from the checkpoint object so it can be used while a transaction is being made.

Fixes #7 