### PR TITLE
siva: add metadata files for library and locations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/golang-lru v0.5.1
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
@@ -17,6 +18,7 @@ require (
 	gopkg.in/src-d/go-git-fixtures.v3 v3.3.0
 	gopkg.in/src-d/go-git.v4 v4.0.0-20190208090203-dcc9f375f4da
 	gopkg.in/src-d/go-siva.v1 v1.5.0 // indirect
+	gopkg.in/yaml.v2 v2.2.2 // indirect
 )
 
 replace gopkg.in/src-d/go-git.v4 => github.com/src-d/go-git v0.0.0-20190322182544-79081164bccd

--- a/siva/library.go
+++ b/siva/library.go
@@ -28,7 +28,8 @@ type Library struct {
 	tmp    billy.Filesystem
 	locReg *locationRegistry
 
-	options LibraryOptions
+	options  LibraryOptions
+	metadata *LibraryMetadata
 }
 
 // LibraryOptions hold configuration options for the library.
@@ -67,6 +68,12 @@ func NewLibrary(
 	fs billy.Filesystem,
 	ops LibraryOptions,
 ) (*Library, error) {
+	metadata, err := LoadLibraryMetadata(fs)
+	if err != nil {
+		// TODO: skip metadata if corrupted?
+		return nil, err
+	}
+
 	lr, err := newLocationRegistry(ops.RegistryCache)
 	if err != nil {
 		return nil, err
@@ -87,11 +94,12 @@ func NewLibrary(
 	}
 
 	return &Library{
-		id:      borges.LibraryID(id),
-		fs:      fs,
-		tmp:     tmp,
-		locReg:  lr,
-		options: ops,
+		id:       borges.LibraryID(id),
+		fs:       fs,
+		tmp:      tmp,
+		locReg:   lr,
+		options:  ops,
+		metadata: metadata,
 	}, nil
 }
 

--- a/siva/library.go
+++ b/siva/library.go
@@ -68,7 +68,7 @@ func NewLibrary(
 	fs billy.Filesystem,
 	ops LibraryOptions,
 ) (*Library, error) {
-	metadata, err := LoadLibraryMetadata(fs)
+	metadata, err := loadLibraryMetadata(fs)
 	if err != nil {
 		// TODO: skip metadata if corrupted?
 		return nil, err
@@ -278,4 +278,27 @@ func (l *Library) Library(id borges.LibraryID) (borges.Library, error) {
 func (l *Library) Libraries() (borges.LibraryIterator, error) {
 	libs := []borges.Library{l}
 	return util.NewLibraryIterator(libs), nil
+}
+
+// Version returns version stored in metadata or -1 if not defined.
+func (l *Library) Version() int {
+	return l.metadata.Version()
+}
+
+// SetVersion sets the current version to the given number.
+func (l *Library) SetVersion(n int) {
+	if l.metadata == nil {
+		l.metadata = NewLibraryMetadata(-1)
+	}
+
+	l.metadata.SetVersion(n)
+}
+
+// SaveMetadata writes the metadata to the library yaml file.
+func (l *Library) SaveMetadata() error {
+	if l.metadata != nil && l.metadata.dirty {
+		return l.metadata.Save(l.fs)
+	}
+
+	return nil
 }

--- a/siva/location.go
+++ b/siva/location.go
@@ -17,6 +17,9 @@ import (
 // ErrMalformedData when checkpoint data is invalid.
 var ErrMalformedData = errors.NewKind("malformed data")
 
+// ErrInvalidSize means that the siva size could not be correctly retrieved.
+var ErrInvalidSize = errors.NewKind("invalid siva size")
+
 // Location represents a siva file archiving several git repositories.
 type Location struct {
 	id         borges.LocationID
@@ -392,4 +395,18 @@ func (l *Location) SaveMetadata() error {
 	}
 
 	return nil
+}
+
+func (l *Location) size() (uint64, error) {
+	stat, err := l.lib.fs.Stat(l.path)
+	if err != nil {
+		return 0, err
+	}
+
+	size := stat.Size()
+	if size < 0 {
+		return 0, ErrInvalidSize.New()
+	}
+
+	return uint64(stat.Size()), nil
 }

--- a/siva/location.go
+++ b/siva/location.go
@@ -40,7 +40,6 @@ func newLocation(
 	path string,
 	create bool,
 ) (*Location, error) {
-	// LibraryMetadataFile is the name of the file that holds library metadatan
 	metadata, err := loadLocationMetadata(lib.fs, locationMetadataPath(path))
 	if err != nil {
 		// TODO: skip metadata if corrupted? log a warning?

--- a/siva/metadata.go
+++ b/siva/metadata.go
@@ -48,7 +48,7 @@ func (m *LibraryMetadata) SetVersion(v int) {
 
 // Save writes metadata to the library yaml file.
 func (m *LibraryMetadata) Save(fs billy.Filesystem) error {
-	data, err := m.yaml()
+	data, err := yaml.Marshal(m)
 	if err != nil {
 		return err
 	}
@@ -67,10 +67,6 @@ func (m *LibraryMetadata) Save(fs billy.Filesystem) error {
 // Dirty returns true if the metadata was changed and it needs to be written.
 func (m *LibraryMetadata) Dirty() bool {
 	return m.dirty
-}
-
-func (m *LibraryMetadata) yaml() ([]byte, error) {
-	return yaml.Marshal(*m)
 }
 
 // parseLibraryMetadata parses the yaml representation of library metadata.
@@ -166,11 +162,6 @@ func locationMetadataPath(path string) string {
 	return path + ".yaml"
 }
 
-// yaml returns the yaml representation of the location metadata.
-func (m *LocationMetadata) yaml() ([]byte, error) {
-	return yaml.Marshal(m)
-}
-
 // Last returns the last Version or -1 if there are no Versions.
 func (m *LocationMetadata) Last() int {
 	if m == nil {
@@ -260,7 +251,7 @@ func (m *LocationMetadata) Dirty() bool {
 
 // Save writes metadata to the yaml file for the give siva path.
 func (m *LocationMetadata) Save(fs billy.Filesystem, path string) error {
-	data, err := m.yaml()
+	data, err := yaml.Marshal(m)
 	if err != nil {
 		return err
 	}

--- a/siva/metadata.go
+++ b/siva/metadata.go
@@ -1,0 +1,156 @@
+package siva
+
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/ghodss/yaml"
+	billy "gopkg.in/src-d/go-billy.v4"
+)
+
+const (
+	// LibraryMetadataFile is the name of the file that holds library metadata.
+	LibraryMetadataFile = "library.yaml"
+)
+
+// LibraryMetadata holds information about the library.
+type LibraryMetadata struct {
+	Version int `json:"version"`
+}
+
+// ParseLibraryMetadata parses the yaml representation of library metadata.
+func ParseLibraryMetadata(d []byte) (*LibraryMetadata, error) {
+	var m LibraryMetadata
+
+	err := yaml.Unmarshal(d, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}
+
+// LoadLibraryMetadata reads and parses a library metadata file.
+func LoadLibraryMetadata(fs billy.Filesystem) (*LibraryMetadata, error) {
+	mf, err := fs.Open(LibraryMetadataFile)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer mf.Close()
+
+	data, err := ioutil.ReadAll(mf)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseLibraryMetadata(data)
+}
+
+// Version describes a bookmark in the siva file.
+type Version struct {
+	// Offset is a position in the siva file.
+	Offset uint64 `json:"offset"`
+	// Size is block size of the version.
+	Size uint64 `json:"size,omiempty"`
+}
+
+// Versions holds a numbered list of bookmarks in the siva file.
+type Versions map[int]Version
+
+// LocationMetadata holds extra data associated with a siva file.
+type LocationMetadata struct {
+	Versions Versions `json:"versions"`
+}
+
+// ParseLocationMetadata parses the yaml representation of location metadata.
+func ParseLocationMetadata(d []byte) (*LocationMetadata, error) {
+	var m LocationMetadata
+
+	err := yaml.Unmarshal(d, &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return &m, nil
+}
+
+// LoadLocationMetadata reads and parses a location metadata file.
+func LoadLocationMetadata(fs billy.Filesystem, path string) (*LocationMetadata, error) {
+	mf, err := fs.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer mf.Close()
+
+	data, err := ioutil.ReadAll(mf)
+	if err != nil {
+		return nil, err
+	}
+
+	return ParseLocationMetadata(data)
+}
+
+// LocationMetadataPath returns the path for a location metadata file.
+func LocationMetadataPath(path string) string {
+	return path + ".yaml"
+}
+
+// ToYaml returns the yaml representation of the location metadata.
+func (m *LocationMetadata) ToYaml() ([]byte, error) {
+	return yaml.Marshal(m)
+}
+
+// Last returns the last version or -1 if there are no versions.
+func (m *LocationMetadata) Last() int {
+	last := -1
+	for i := range m.Versions {
+		if i > last {
+			last = i
+		}
+	}
+
+	return last
+}
+
+// closest searches for the last version lesser or equal to the one provided.
+func (m *LocationMetadata) closest(v int) int {
+	closest := -1
+	for i := range m.Versions {
+		if i <= v && i > closest {
+			closest = i
+		}
+	}
+
+	return closest
+}
+
+// OffsetFromLibrary picks the version from Library metadata and returns its
+// offsets. If the version does not exist it selects the closest previous
+// version. In case there's no Library metadata it picks the latest version.
+// If there are not versions defined returns offset 0 that means to use
+// the latest siva index when used with siva filesystem.
+func (m *LocationMetadata) OffsetFromLibrary(l *LibraryMetadata) uint64 {
+	version := m.Last()
+
+	if version == -1 {
+		return 0
+	}
+
+	if l != nil {
+		if v, ok := m.Versions[l.Version]; ok {
+			return v.Offset
+		}
+
+		if closest := m.closest(l.Version); closest >= 0 {
+			version = closest
+		}
+	}
+
+	return m.Versions[version].Offset
+}

--- a/siva/metadata_test.go
+++ b/siva/metadata_test.go
@@ -1,0 +1,168 @@
+package siva
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/src-d/go-borges"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/src-d/go-billy.v4/util"
+)
+
+func TestMetadataSiva(t *testing.T) {
+	require := require.New(t)
+
+	meta := LocationMetadata{
+		Versions: Versions{
+			0: {
+				Offset: 16,
+				Size:   17,
+			},
+			1: {
+				Offset: 32,
+				Size:   33,
+			},
+			10: {
+				Offset: 42,
+				Size:   43,
+			},
+			20: {
+				Offset: 52,
+				Size:   53,
+			},
+			2: {
+				Offset: 62,
+				Size:   63,
+			},
+		},
+	}
+
+	data, err := meta.ToYaml()
+	require.NoError(err)
+
+	m, err := ParseLocationMetadata(data)
+	require.NoError(err)
+	require.EqualValues(meta, *m)
+}
+
+const (
+	rootedVersions = `
+---
+versions:
+  "0":
+    offset: 3180
+  "1":
+    offset: 6557
+  "5":
+    offset: 10296
+  "6":
+    offset: 17421
+`
+
+	libMetadata = `---
+version: `
+)
+
+func TestMetadataLibrary(t *testing.T) {
+
+	tests := []struct {
+		version      int
+		repositories []string
+	}{
+		{
+			version: 0,
+			repositories: []string{
+				"gitserver.com/a",
+			},
+		},
+		{
+			version: 1,
+			repositories: []string{
+				"gitserver.com/a",
+				"gitserver.com/b",
+			},
+		},
+		{
+			version: 2,
+			repositories: []string{
+				"gitserver.com/a",
+				"gitserver.com/b",
+			},
+		},
+		{
+			version: 3,
+			repositories: []string{
+				"gitserver.com/a",
+				"gitserver.com/b",
+			},
+		},
+		{
+			version: 4,
+			repositories: []string{
+				"gitserver.com/a",
+				"gitserver.com/b",
+			},
+		},
+		{
+			version: 5,
+			repositories: []string{
+				"gitserver.com/a",
+				"gitserver.com/b",
+				"gitserver.com/c",
+			},
+		},
+		{
+			version: 6,
+			repositories: []string{
+				"gitserver.com/a",
+				"gitserver.com/b",
+				"gitserver.com/c",
+				"gitserver.com/d",
+			},
+		},
+		{
+			version: -1,
+			repositories: []string{
+				"gitserver.com/a",
+				"gitserver.com/b",
+				"gitserver.com/c",
+				"gitserver.com/d",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("version-%v", test.version), func(t *testing.T) {
+			require := require.New(t)
+			fs, _ := setupFS(t, "../_testdata/rooted", true, 0)
+
+			if test.version != -1 {
+				libMd := libMetadata + strconv.Itoa(test.version)
+				err := util.WriteFile(fs, LibraryMetadataFile, []byte(libMd), 0666)
+				require.NoError(err)
+			}
+
+			path := LocationMetadataPath("cf2e799463e1a00dbd1addd2003b0c7db31dbfe2.siva")
+			err := util.WriteFile(fs, path, []byte(rootedVersions), 0666)
+			require.NoError(err)
+
+			lib, err := NewLibrary("test", fs, LibraryOptions{})
+			require.NoError(err)
+
+			it, err := lib.Repositories(borges.ReadOnlyMode)
+			require.NoError(err)
+
+			var repositories []string
+			err = it.ForEach(func(r borges.Repository) error {
+				repositories = append(repositories, r.ID().String())
+				return nil
+			})
+			require.NoError(err)
+
+			require.ElementsMatch(test.repositories, repositories)
+		})
+	}
+
+}

--- a/siva/metadata_test.go
+++ b/siva/metadata_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/ghodss/yaml"
 	"github.com/src-d/go-borges"
 
 	"github.com/stretchr/testify/require"
@@ -41,7 +42,7 @@ func TestMetadataSiva(t *testing.T) {
 		},
 	}
 
-	data, err := meta.yaml()
+	data, err := yaml.Marshal(meta)
 	require.NoError(err)
 
 	m, err := parseLocationMetadata(data)


### PR DESCRIPTION
Location metadata has a set of bookmarks in the history of the siva file
called versions. Library metadata specifies which version to use.

Closes #22 