### PR TITLE
siva: checkpoints should only be applied explicitly

### DIFF
--- a/siva/checkpoint.go
+++ b/siva/checkpoint.go
@@ -58,11 +58,6 @@ func newCheckpoint(fs billy.Filesystem, path string, create bool) (*checkpoint, 
 	}
 
 	c.offset = offset
-
-	if err := c.Apply(); err != nil {
-		return nil, err
-	}
-
 	return c, nil
 }
 

--- a/siva/checkpoint_test.go
+++ b/siva/checkpoint_test.go
@@ -105,6 +105,10 @@ func (s *checkpointSuite) TestNew_Prev_Checkpoint_File() {
 
 			cp, err := newCheckpoint(s.fs, siva, false)
 			require.NoError(err)
+			require.Equal(int64(10), cp.offset)
+
+			err = cp.Apply()
+			require.NoError(err)
 			require.Equal(int64(-1), cp.offset)
 
 			info, err := s.fs.Lstat(siva)


### PR DESCRIPTION
On opening all locations were truncated to the latest known good state. This is not the desired behavior as the location may be being updated by another process.
