### PR TITLE
siva: cache references and config from locations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67 // indirect
-	golang.org/x/net v0.0.0-20190206173232-65e2d4e15006 // indirect
-	golang.org/x/sys v0.0.0-20190209173611-3b5209105503 // indirect
+	golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529 // indirect
 	gopkg.in/src-d/go-billy-siva.v4 v4.5.1
 	gopkg.in/src-d/go-billy.v4 v4.3.0
 	gopkg.in/src-d/go-errors.v1 v1.0.0

--- a/siva/checkpoint.go
+++ b/siva/checkpoint.go
@@ -3,6 +3,7 @@ package siva
 import (
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 
 	borges "github.com/src-d/go-borges"
@@ -174,7 +175,8 @@ func readInt64(fs billy.Filesystem, path string) (int64, error) {
 		return -1, err
 	}
 
-	num, err := strconv.ParseInt(string(data[:n]), 10, 64)
+	str := strings.TrimSpace(string(data[:n]))
+	num, err := strconv.ParseInt(str, 10, 64)
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
This makes retrieving repositories faster. It invalidates cache when the file is modified (size and modification time) or the version is changed.