### PR TITLE
siva: fix error truncating siva files

### DIFF
--- a/siva/checkpoint.go
+++ b/siva/checkpoint.go
@@ -78,7 +78,7 @@ func (c *checkpoint) Apply() error {
 			return c.reset()
 		}
 
-		f, err := c.baseFs.Open(c.path)
+		f, err := c.baseFs.OpenFile(c.path, os.O_RDWR, 0664)
 		if err != nil {
 			return ErrCannotUseSivaFile.Wrap(err, c.path)
 		}


### PR DESCRIPTION
The the file was opened in read only mode so truncate fails. The tests passed because they were done in `memfs` that does not check if the file is in read only mode. Checkpoint tests now run in real filesystem.

Fixes #43 