### PR TITLE
*: add timeouts to potentially long running library operations

### DIFF
--- a/libraries/libraries.go
+++ b/libraries/libraries.go
@@ -1,6 +1,8 @@
 package libraries
 
 import (
+	"time"
+
 	"github.com/src-d/go-borges"
 	"github.com/src-d/go-borges/util"
 
@@ -16,12 +18,16 @@ var (
 // FilterLibraryFunc stands for a borges.Library filter function.
 type FilterLibraryFunc func(borges.Library) (bool, error)
 
-// RepositoryIterFunc stands for a function to return a
+// RepositoryIterFunc stands for a function returning a
 // borges.RepositoryIterator which iters in a certain order.
 type RepositoryIterFunc func(*Libraries, borges.Mode) (borges.RepositoryIterator, error)
 
 // Options hold configuration options for a Libraries.
 type Options struct {
+	// Timeout set a timeout for library operations. Some operations could
+	// potentially take long so timing out them will make an error be
+	// returned. A 0 value sets a default value of 60 seconds.
+	Timeout             time.Duration
 	RepositoryIterOrder RepositoryIterFunc
 }
 
@@ -34,6 +40,10 @@ type Libraries struct {
 
 var _ borges.Library = (*Libraries)(nil)
 
+const (
+	timeout = 60 * time.Second
+)
+
 // New create a new Libraries instance.
 func New(options *Options) *Libraries {
 	var opts *Options
@@ -45,6 +55,10 @@ func New(options *Options) *Libraries {
 
 	if opts.RepositoryIterOrder == nil {
 		opts.RepositoryIterOrder = RepositoryDefaultIter
+	}
+
+	if opts.Timeout == 0 {
+		opts.Timeout = timeout
 	}
 
 	return &Libraries{

--- a/libraries/libraries_test.go
+++ b/libraries/libraries_test.go
@@ -182,7 +182,11 @@ func TestLibrariesRepositoriesError(t *testing.T) {
 	_, err := lbaz.Init(nbaz)
 	require.NoError(err)
 
-	plainLib := plain.NewLibrary(borges.LibraryID("broken"))
+	plainLib := plain.NewLibrary(
+		borges.LibraryID("broken"),
+		&plain.LibraryOptions{},
+	)
+
 	plainLib.AddLocation(lqux)
 	plainLib.AddLocation(lbar)
 	plainLib.AddLocation(lbaz)

--- a/siva/repository_test.go
+++ b/siva/repository_test.go
@@ -363,7 +363,7 @@ func (s *repoSuite) TestTransaction_Timeout() {
 
 	var require = s.Require()
 
-	s.lib.options.Timeout = 100 * time.Millisecond
+	s.lib.options.TransactionTimeout = 100 * time.Millisecond
 
 	loc, err := s.lib.AddLocation("test")
 	require.NoError(err)


### PR DESCRIPTION
Closes #66 

For `libraries` subpackage the timeout option is added but it still doesn't handle it. If this is aproved I'll manage it in another PR since it requires change the functions to select the iteration order of the libraries to accept contexts.