### PR TITLE
libraries: manage Library timeout

### DIFF
--- a/libraries/iterator.go
+++ b/libraries/iterator.go
@@ -10,6 +10,8 @@ import (
 )
 
 // MergeRepositoryIterators builds a new iterator from the given ones.
+// The merged iterator will keep the order of the given slice of iterators to
+// iterate them.
 func MergeRepositoryIterators(iters []borges.RepositoryIterator) borges.RepositoryIterator {
 	return &mergedRepoIter{iters: iters}
 }
@@ -291,10 +293,10 @@ func (i *jumpLibsRepoIter) Close() {
 	}
 }
 
-// RepoIterSivasJumpLocations returns a borges.RepositoryIterator with the same
+// RepoIterJumpSivaLocations returns a borges.RepositoryIterator with the same
 // properties as the one returned by RepoIterJumpLocations but using only those
 // libraries of type siva.Library.
-func RepoIterSivasJumpLocations(
+func RepoIterJumpSivaLocations(
 	libs *Libraries,
 	mode borges.Mode,
 ) (borges.RepositoryIterator, error) {

--- a/libraries/iterator_test.go
+++ b/libraries/iterator_test.go
@@ -50,7 +50,7 @@ func TestRepositoryIterFuncs(t *testing.T) {
 	require.NoError(err)
 	require.ElementsMatch(expected, toSlice(t, iter))
 
-	iter, err = RepoIterSivasJumpLocations(libs, borges.ReadOnlyMode)
+	iter, err = RepoIterJumpSivaLocations(libs, borges.ReadOnlyMode)
 	require.NoError(err)
 	require.ElementsMatch(expected, toSlice(t, iter))
 

--- a/libraries/libraries.go
+++ b/libraries/libraries.go
@@ -1,6 +1,7 @@
 package libraries
 
 import (
+	"context"
 	"time"
 
 	"github.com/src-d/go-borges"
@@ -91,7 +92,16 @@ func (l *Libraries) Init(borges.RepositoryID) (borges.Repository, error) {
 
 // Get implements the Library interface.
 func (l *Libraries) Get(id borges.RepositoryID, mode borges.Mode) (borges.Repository, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), l.opts.Timeout)
+	defer cancel()
+
 	for _, lib := range l.libs {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		r, err := lib.Get(id, mode)
 		if err != nil {
 			if borges.ErrRepositoryNotExists.Is(err) {
@@ -114,7 +124,16 @@ func (l *Libraries) GetOrInit(borges.RepositoryID) (borges.Repository, error) {
 
 // Has implements the Library interface.
 func (l *Libraries) Has(id borges.RepositoryID) (bool, borges.LibraryID, borges.LocationID, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), l.opts.Timeout)
+	defer cancel()
+
 	for _, lib := range l.libs {
+		select {
+		case <-ctx.Done():
+			return false, "", "", ctx.Err()
+		default:
+		}
+
 		has, libID, locID, err := lib.Has(id)
 		if err != nil {
 			return false, "", "", err
@@ -135,7 +154,16 @@ func (l *Libraries) Repositories(mode borges.Mode) (borges.RepositoryIterator, e
 
 // Location implements the Library interface.
 func (l *Libraries) Location(id borges.LocationID) (borges.Location, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), l.opts.Timeout)
+	defer cancel()
+
 	for _, lib := range l.libs {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		loc, err := lib.Location(id)
 		if err != nil {
 			if borges.ErrLocationNotExists.Is(err) {
@@ -153,8 +181,17 @@ func (l *Libraries) Location(id borges.LocationID) (borges.Location, error) {
 
 // Locations implements the Library interface.
 func (l *Libraries) Locations() (borges.LocationIterator, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), l.opts.Timeout)
+	defer cancel()
+
 	var locations []borges.LocationIterator
 	for _, lib := range l.libs {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		locs, err := lib.Locations()
 		if err != nil {
 			return nil, err
@@ -195,8 +232,17 @@ func (l *Libraries) FilteredLibraries(filter FilterLibraryFunc) (borges.LibraryI
 }
 
 func (l *Libraries) libraries(filter FilterLibraryFunc) ([]borges.Library, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), l.opts.Timeout)
+	defer cancel()
+
 	libs := make([]borges.Library, 0, len(l.libs))
 	for _, lib := range l.libs {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
 		ok, err := filter(lib)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Closes #74 

For manage timeouts in the merged iterators I think it's better wait to add contexts to the iterators interfaces.