### PR TITLE
siva: new library metadata should point to latest version

### DIFF
--- a/siva/metadata.go
+++ b/siva/metadata.go
@@ -60,7 +60,7 @@ func newLibraryMetadata(
 ) (*libMetadata, error) {
 	m := &libMetadata{
 		ID:             id,
-		CurrentVersion: 0,
+		CurrentVersion: -1,
 		fs:             fs,
 		dirty:          true,
 	}

--- a/siva/metadata_test.go
+++ b/siva/metadata_test.go
@@ -208,7 +208,7 @@ func TestMetadataLibraryWrite(t *testing.T) {
 
 	version, err = lib.Version()
 	require.NoError(err)
-	require.Equal(0, version)
+	require.Equal(-1, version)
 	require.Equal(borges.LibraryID("test"), lib.ID())
 
 	require.NoError(lib.SetVersion(1))


### PR DESCRIPTION
Libraries without an specific version should read the latest defined version for each location instead of version `0`.