### PR TITLE
siva: fix placement of metadata files with bucket

### DIFF
--- a/siva/library.go
+++ b/siva/library.go
@@ -2,7 +2,6 @@ package siva
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -271,9 +270,17 @@ func (l *Library) location(id borges.LocationID, create bool) (borges.Location, 
 }
 
 func buildSivaPath(id borges.LocationID, bucket int) string {
-	siva := fmt.Sprintf("%s.siva", id)
+	return buildPath(id, bucket, ".siva")
+}
+
+func buildSivaMetadataPath(id borges.LocationID, bucket int) string {
+	return buildPath(id, bucket, locMetadataFileExt)
+}
+
+func buildPath(id borges.LocationID, bucket int, suffix string) string {
+	name := string(id) + suffix
 	if bucket == 0 {
-		return siva
+		return name
 	}
 
 	r := []rune(id)
@@ -284,7 +291,7 @@ func buildSivaPath(id borges.LocationID, bucket int) string {
 		bucketDir = string(r[:bucket])
 	}
 
-	return filepath.Join(bucketDir, siva)
+	return filepath.Join(bucketDir, name)
 }
 
 // Locations implements borges.Library interface.

--- a/siva/location.go
+++ b/siva/location.go
@@ -61,7 +61,8 @@ func newLocation(
 	var metadata *locationMetadata
 	if lib.metadata != nil {
 		var err error
-		metadata, err = loadOrCreateLocationMetadata(lib.fs, string(id))
+		mPath := buildSivaMetadataPath(id, lib.options.Bucket)
+		metadata, err = loadOrCreateLocationMetadata(lib.fs, mPath)
 		if err != nil {
 			// TODO: skip metadata if corrupted? log a warning?
 			return nil, err

--- a/siva/metadata.go
+++ b/siva/metadata.go
@@ -218,13 +218,13 @@ type locationMetadata struct {
 const locMetadataFileExt = ".yaml"
 
 func newLocationMetadata(
-	id string,
 	fs billy.Filesystem,
+	path string,
 ) *locationMetadata {
 	return &locationMetadata{
 		Versions: make(map[int]*Version),
 		fs:       fs,
-		path:     id + locMetadataFileExt,
+		path:     path,
 	}
 }
 
@@ -241,12 +241,11 @@ func parseLocationMetadata(d []byte) (*locationMetadata, error) {
 
 func loadOrCreateLocationMetadata(
 	fs billy.Filesystem,
-	id string,
+	path string,
 ) (*locationMetadata, error) {
-	path := id + locMetadataFileExt
 	m, err := loadLocationMetadata(fs, path)
 	if os.IsNotExist(err) {
-		return newLocationMetadata(id, fs), nil
+		return newLocationMetadata(fs, path), nil
 	}
 
 	return m, err


### PR DESCRIPTION
Location metadata files were placed in the library root path instead in
the siva directory.

    cf/cf2e799463e1a00dbd1addd2003b0c7db31dbfe2.siva
    cf2e799463e1a00dbd1addd2003b0c7db31dbfe2.yaml

instead of:

    cf/cf2e799463e1a00dbd1addd2003b0c7db31dbfe2.siva
    cf/cf2e799463e1a00dbd1addd2003b0c7db31dbfe2.yaml
