### PR TITLE
fix race conditions on iterators

### DIFF
--- a/libraries/iterator.go
+++ b/libraries/iterator.go
@@ -2,6 +2,7 @@ package libraries
 
 import (
 	"io"
+	"sync"
 
 	"github.com/src-d/go-borges"
 	"github.com/src-d/go-borges/plain"
@@ -17,6 +18,7 @@ func MergeRepositoryIterators(iters []borges.RepositoryIterator) borges.Reposito
 }
 
 type mergedRepoIter struct {
+	mu    sync.Mutex
 	iters []borges.RepositoryIterator
 }
 
@@ -24,6 +26,9 @@ var _ borges.RepositoryIterator = (*mergedRepoIter)(nil)
 
 // Next implements the borges.RepositoryIterator interface.
 func (i *mergedRepoIter) Next() (borges.Repository, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	for {
 		if len(i.iters) == 0 {
 			return nil, io.EOF
@@ -55,6 +60,9 @@ func (i *mergedRepoIter) ForEach(cb func(borges.Repository) error) error {
 
 // Close implements the borges.RepositoryIterator interface.
 func (i *mergedRepoIter) Close() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	for _, iter := range i.iters {
 		iter.Close()
 	}
@@ -66,6 +74,7 @@ func MergeLocationIterators(iters []borges.LocationIterator) borges.LocationIter
 }
 
 type mergedLocationIter struct {
+	mu    sync.Mutex
 	iters []borges.LocationIterator
 }
 
@@ -73,6 +82,9 @@ var _ borges.LocationIterator = (*mergedLocationIter)(nil)
 
 // Next implements the borges.LocationIterator interface.
 func (i *mergedLocationIter) Next() (borges.Location, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	for {
 		if len(i.iters) == 0 {
 			return nil, io.EOF
@@ -104,6 +116,9 @@ func (i *mergedLocationIter) ForEach(cb func(borges.Location) error) error {
 
 // Close implements the borges.LocationIterator interface.
 func (i *mergedLocationIter) Close() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	for _, iter := range i.iters {
 		iter.Close()
 	}
@@ -115,6 +130,7 @@ func MergeLibraryIterators(iters []borges.LibraryIterator) borges.LibraryIterato
 }
 
 type mergedLibIter struct {
+	mu    sync.Mutex
 	iters []borges.LibraryIterator
 }
 
@@ -122,6 +138,9 @@ var _ borges.LibraryIterator = (*mergedLibIter)(nil)
 
 // Next implements the borges.LibraryIterator interface.
 func (i *mergedLibIter) Next() (borges.Library, error) {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	for {
 		if len(i.iters) == 0 {
 			return nil, io.EOF
@@ -153,6 +172,9 @@ func (i *mergedLibIter) ForEach(cb func(borges.Library) error) error {
 
 // Close implements the borges.LibraryIterator interface.
 func (i *mergedLibIter) Close() {
+	i.mu.Lock()
+	defer i.mu.Unlock()
+
 	for _, iter := range i.iters {
 		iter.Close()
 	}


### PR DESCRIPTION
during `gitbase` [tests](https://github.com/src-d/gitbase/issues/955) execution on the binary built with race detection flag the race was detected
```go
==================
WARNING: DATA RACE
Read at 0x00c000cf43e0 by goroutine 22:
  github.com/src-d/go-borges/libraries.(*mergedRepoIter).Close()
      /home/lwsanty/goproj/lwsanty/go-borges/libraries/iterator.go:57 +0x3e
  github.com/src-d/gitbase.(*repositoryPartitionIter).Close()
      /home/lwsanty/goproj/lwsanty/gitbase/partition.go:96 +0x7b
  github.com/src-d/go-mysql-server/sql/plan.(*exchangeRowIter).Close()
      /home/lwsanty/goproj/lwsanty/go-mysql-server/sql/plan/exchange.go:289 +0xca
  github.com/src-d/go-mysql-server/sql/plan.(*limitIter).Close()
      /home/lwsanty/goproj/lwsanty/go-mysql-server/sql/plan/limit.go:77 +0x55
  github.com/src-d/go-mysql-server/sql.(*spanIter).Close()
      /home/lwsanty/goproj/lwsanty/go-mysql-server/sql/session.go:416 +0x71
  github.com/src-d/go-mysql-server/sql/plan.(*trackedRowIter).Close()
      /home/lwsanty/goproj/lwsanty/go-mysql-server/sql/plan/process.go:142 +0x73
  github.com/src-d/go-mysql-server/server.(*Handler).ComQuery()
      /home/lwsanty/goproj/lwsanty/go-mysql-server/server/handler.go:278 +0xfa7
  vitess.io/vitess/go/mysql.(*Conn).execQuery()
      /home/lwsanty/goproj/gopath/pkg/mod/vitess.io/vitess@v3.0.0-rc.3.0.20190602171040-12bfde34629c+incompatible/go/mysql/conn.go:819 +0x20b
  vitess.io/vitess/go/mysql.(*Conn).handleNextCommand()
      /home/lwsanty/goproj/gopath/pkg/mod/vitess.io/vitess@v3.0.0-rc.3.0.20190602171040-12bfde34629c+incompatible/go/mysql/conn.go:749 +0x16f8
  vitess.io/vitess/go/mysql.(*Listener).handle()
      /home/lwsanty/goproj/gopath/pkg/mod/vitess.io/vitess@v3.0.0-rc.3.0.20190602171040-12bfde34629c+incompatible/go/mysql/server.go:441 +0x1446

Previous write at 0x00c000cf43e0 by goroutine 28:
  github.com/src-d/go-borges/libraries.(*mergedRepoIter).Next()
      /home/lwsanty/goproj/lwsanty/go-borges/libraries/iterator.go:37 +0x1b0
  github.com/src-d/gitbase.(*repositoryPartitionIter).Next()
      /home/lwsanty/goproj/lwsanty/gitbase/partition.go:79 +0x7e
  github.com/src-d/go-mysql-server/sql/plan.(*exchangeRowIter).iterPartitions()
      /home/lwsanty/goproj/lwsanty/go-mysql-server/sql/plan/exchange.go:195 +0x292

Goroutine 22 (running) created at:
  vitess.io/vitess/go/mysql.(*Listener).Accept()
      /home/lwsanty/goproj/gopath/pkg/mod/vitess.io/vitess@v3.0.0-rc.3.0.20190602171040-12bfde34629c+incompatible/go/mysql/server.go:243 +0x188
  github.com/src-d/gitbase/cmd/gitbase/command.(*Server).Execute()
      /home/lwsanty/goproj/lwsanty/go-mysql-server/server/server.go:79 +0xc8d
  github.com/jessevdk/go-flags.(*Parser).ParseArgs()
      /home/lwsanty/goproj/gopath/pkg/mod/github.com/jessevdk/go-flags@v1.4.0/parser.go:316 +0xf57
  main.main()
      /home/lwsanty/goproj/gopath/pkg/mod/github.com/jessevdk/go-flags@v1.4.0/parser.go:186 +0x8a3

Goroutine 28 (finished) created at:
  github.com/src-d/go-mysql-server/sql/plan.(*exchangeRowIter).start()
      /home/lwsanty/goproj/lwsanty/go-mysql-server/sql/plan/exchange.go:143 +0xa0
==================
```

this PR provides fix to the current race

related to https://github.com/src-d/gitbase/issues/955

Signed-off-by: lwsanty <lwsanty@gmail.com>